### PR TITLE
Use POST instead of GET in express server

### DIFF
--- a/index.js
+++ b/index.js
@@ -495,7 +495,7 @@ https://github.com/TiagoDanin/Telegraf-Test
 			*/
 		}
 
-		this.server.get('/bot:token/:method', (req, res) => {
+		this.server.post('/bot:token/:method', (req, res) => {
 			if (req.params.token !== this.options.token) {
 				return res.json({
 					ok: false,


### PR DESCRIPTION
This is necessary for compatibility with [Telegraf API requests](https://github.com/telegraf/telegraf/blob/ba2f4a2e66a149cd51efc555e01bcc21cb43ed5b/core/network/client.js#L75) which use POST
